### PR TITLE
update gateway docs

### DIFF
--- a/modules/ROOT/partials/attributes.adoc
+++ b/modules/ROOT/partials/attributes.adoc
@@ -19,8 +19,9 @@
 // name and version
 :skupper-name: Skupper
 :service-network: service network
-:skupper-version: 1.0
-:skupper-cli-version: {skupper-version}
+:skupper-version: 1.2
+:service-version: 2.2.0
+:skupper-cli-version: {skupper-version}.0
 :SkupperOperatorName: Skupper Operator
 :skupper-router: Skupper router
 :policy-system: policy system

--- a/modules/cli/pages/index.adoc
+++ b/modules/cli/pages/index.adoc
@@ -388,11 +388,12 @@ $ skupper gateway expose mysql 192.168.1.200 3306
 . Check the status of Skupper gateways:
 +
 --
+[subs=attributes+]
 ----
 $ skupper gateway status
 
 Gateway Definition:
-╰─ machine-user type:service version:2.2.0
+╰─ machine-user type:service version:{service-version}
    ╰─ Bindings:
       ╰─ mydb:3306 tcp mydb:3306 localhost 3306
 
@@ -462,12 +463,13 @@ $ skupper gateway bind <service> <host> <port>
 . Check the status of Skupper gateways:
 +
 --
+[subs=attributes+]
 ----
 $ skupper gateway status
 Gateway Definitions Summary
 
 Gateway Definition:
-╰─ machine-user type:service version:2.2.0
+╰─ machine-user type:service version:{service-version}
    ╰─ Bindings:
       ╰─ mydb:3306 tcp mydb:3306 localhost 3306
 
@@ -625,10 +627,11 @@ NOTE: You can later remove the gateway using `./remove.py`.
 . From the machine with cluster access, check the status of Skupper gateways:
 +
 --
+[subs=attributes+]
 ----
 $ skupper gateway status
 Gateway Definition:
-╰─ machine-user type:service version:2.2.0
+╰─ machine-user type:service version:{service-version}
    ╰─ Bindings:
       ╰─ mydb:3306 tcp mydb:3306 localhost 3306
 ----

--- a/modules/cli/pages/index.adoc
+++ b/modules/cli/pages/index.adoc
@@ -392,9 +392,9 @@ $ skupper gateway expose mysql 192.168.1.200 3306
 $ skupper gateway status
 
 Gateway Definition:
-╰─ machine-user type:service version:1.18.0
+╰─ machine-user type:service version:2.2.0
    ╰─ Bindings:
-      ╰─ mydb:3306 tcp mydb:3306 127.0.0.1 3306
+      ╰─ mydb:3306 tcp mydb:3306 localhost 3306
 
 ----
 This shows that there is only one exposed service and that service is only exposing a single port (BIND). There are no ports forwarded to the local host.
@@ -467,9 +467,9 @@ $ skupper gateway status
 Gateway Definitions Summary
 
 Gateway Definition:
-╰─ machine-user type:service version:1.18.0
+╰─ machine-user type:service version:2.2.0
    ╰─ Bindings:
-      ╰─ mydb:3306 tcp mydb:3306 127.0.0.1 3306
+      ╰─ mydb:3306 tcp mydb:3306 localhost 3306
 
 ----
 This shows that there is only one exposed service and that service is only exposing a single port (BIND). There are no ports forwarded to the local host.
@@ -627,10 +627,10 @@ NOTE: You can later remove the gateway using `./remove.py`.
 --
 ----
 $ skupper gateway status
-Gateway Definitions Summary
-
-NAME    BINDS  FORWARDS  URL                    
-<machine-name>  1      0         amqp://127.0.0.1:5672 
+Gateway Definition:
+╰─ machine-user type:service version:2.2.0
+   ╰─ Bindings:
+      ╰─ mydb:3306 tcp mydb:3306 localhost 3306
 ----
 This shows that there is only one exposed service and that service is only exposing a single port (BIND). There are no ports forwarded to the local host.
 --


### PR DESCRIPTION
@ajssmith I went thru the gateway docs and made some small updates:

1. We don't have anything for 'export-config', but that's not main flow, right?
2. When I do export-config I got the following, should we document these fields?

```
        enabletls: false
        tlscredentials: ""
        publishnotreadyaddresses: false
```
3. Should version numbers be variables?
