### PR TITLE
Check the status of the Podman socket with --user

### DIFF
--- a/cli/podman.adoc
+++ b/cli/podman.adoc
@@ -100,9 +100,9 @@ network_backend = "netavark"
 * Podman service endpoint.
 +
 --
-Use `systemctl status podman.socket` to make sure the Podman API Socket is running.
+Use `systemctl --user status podman.socket` to make sure the Podman API Socket is running.
 
-Use `systemctl --user enable --now podman.socket` to start the  Podman API Socket.
+If the socket isn't running, use `systemctl --user enable --now podman.socket` to start it.
 
 See link:https://github.com/containers/podman/blob/main/docs/tutorials/socket_activation.md[Podman socket activation] for information about enabling this endpoint.
 --


### PR DESCRIPTION
Since the Podman socket is a user service, its status must be checked with --user.