### PR TITLE
Correct Typo in listener section

### DIFF
--- a/input/kube-cli/service-exposure.md
+++ b/input/kube-cli/service-exposure.md
@@ -70,7 +70,7 @@ For more information about listeners. see [Listener concept][listener].
 
 2. Create a listener:
    ```bash
-   skupper connector create <name> <port> [--routing-key <name>]
+   skupper listener create <name> <port> [--routing-key <name>]
    ```
    For example:
    ```


### PR DESCRIPTION
The command in the listener section was skupper connector create ... instead of skupper listener create...